### PR TITLE
Upgrade Que to 2.4.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,7 +17,7 @@ gem 'jbuilder', '~> 2.5'
 gem 'bcrypt', '~> 3.1.7'
 gem 'aws-sdk-s3'
 gem 'kaminari', '~> 1.2'
-gem 'que', github: "que-rb/que", ref: "v1.3.1"
+gem 'que', github: "que-rb/que", ref: "v2.4.1"
 # The 0.202 line deadlocks with Rails 7.0 transaction handling.
 gem 'state_machines', '~> 0.20.0'
 gem 'state_machines-activerecord', '~> 0.8.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/que-rb/que.git
-  revision: e51f6c1826f12ccf07018b1cee3c9adfb456b3f7
-  ref: v1.3.1
+  revision: 17fb2c3b75b37599bf17043dbb692555f582f249
+  ref: v2.4.1
   specs:
-    que (1.3.1)
+    que (2.4.1)
 
 GEM
   remote: https://rubygems.org/
@@ -263,7 +263,7 @@ GEM
     ruby-vips (2.3.0)
       ffi (~> 1.12)
       logger
-    rubyzip (2.4.1)
+    rubyzip (3.4.1)
     sass (3.7.4)
       sass-listen (~> 4.0.0)
     sass-listen (4.0.0)
@@ -278,9 +278,11 @@ GEM
     scout_apm (6.2.0)
       parser
     securerandom (0.4.1)
-    selenium-webdriver (4.10.0)
+    selenium-webdriver (4.46.0)
+      base64 (~> 0.2)
+      logger (~> 1.4)
       rexml (~> 3.2, >= 3.2.5)
-      rubyzip (>= 1.2.2, < 3.0)
+      rubyzip (>= 1.2.2, < 4.0)
       websocket (~> 1.0)
     sentry-raven (3.1.2)
       faraday (>= 1.0)
@@ -322,10 +324,10 @@ GEM
       activemodel (>= 6.0.0)
       bindex (>= 0.4.0)
       railties (>= 6.0.0)
-    webdrivers (5.3.1)
+    webdrivers (5.2.0)
       nokogiri (~> 1.6)
       rubyzip (>= 1.3.0)
-      selenium-webdriver (~> 4.0, < 4.11)
+      selenium-webdriver (~> 4.0)
     websocket (1.2.11)
     websocket-driver (0.8.2)
       base64

--- a/app/controllers/consumables/images_controller.rb
+++ b/app/controllers/consumables/images_controller.rb
@@ -55,7 +55,7 @@ class Consumables::ImagesController < ApplicationController
       @image.destroy
 
       # Process this ASAP, because there's a human waiting for it now
-      ShrinkImageJob.set(priority: 0).enqueue(@consumable.id, @new_image.id)
+      ShrinkImageJob.enqueue(@consumable.id, @new_image.id, job_options: { priority: 0 })
     ensure
       File.unlink(basename) if File.exist?(basename)
       File.unlink(updname) if File.exist?(updname)

--- a/app/controllers/entities/images_controller.rb
+++ b/app/controllers/entities/images_controller.rb
@@ -56,7 +56,7 @@ class Entities::ImagesController < ApplicationController
       @image.destroy
 
       # Process this ASAP, because there's a human waiting for it now
-      ShrinkImageJob.enqueue(@entity.id, @new_image.id, priority: 0)
+      ShrinkImageJob.enqueue(@entity.id, @new_image.id, job_options: { priority: 0 })
     ensure
       File.unlink(basename) if File.exist?(basename)
       File.unlink(updname) if File.exist?(updname)

--- a/app/jobs/remove_obsolete_member_sessions.rb
+++ b/app/jobs/remove_obsolete_member_sessions.rb
@@ -3,7 +3,7 @@ class RemoveObsoleteMemberSessions < ApplicationJob
     MemberSession.transaction do
       MemberSession.where("created_at < ?", 6.hours.ago).delete_all
       destroy
-      RemoveObsoleteMemberSessions.enqueue(run_at: 4.hours.from_now)
+      RemoveObsoleteMemberSessions.enqueue(job_options: { run_at: 4.hours.from_now })
     end
   end
 end

--- a/db/migrate/20260731034500_upgrade_que_schema_to_version_7.rb
+++ b/db/migrate/20260731034500_upgrade_que_schema_to_version_7.rb
@@ -1,0 +1,9 @@
+class UpgradeQueSchemaToVersion7 < ActiveRecord::Migration[7.0]
+  def up
+    Que.migrate!(version: 7)
+  end
+
+  def down
+    Que.migrate!(version: 5)
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1,4 +1,4 @@
-\restrict HksAl2VB6bLjiIiZcjSaG8oUsAWODVCzXNE7H2fhkINcnKslGVTx2Q5ZRrBgxf6
+\restrict gDfLRO1DwcfZvR3rRAO6rhiY0ZxmG4IHbOjp6dJhW10CbQLnPVa4NtK9KQOfJZp
 
 -- Dumped from database version 18.4 (Homebrew)
 -- Dumped by pg_dump version 18.4 (Homebrew)
@@ -80,7 +80,8 @@ CREATE TABLE public.que_jobs (
     expired_at timestamp with time zone,
     args jsonb DEFAULT '[]'::jsonb NOT NULL,
     data jsonb DEFAULT '{}'::jsonb NOT NULL,
-    job_schema_version integer DEFAULT 1,
+    job_schema_version integer NOT NULL,
+    kwargs jsonb DEFAULT '{}'::jsonb NOT NULL,
     CONSTRAINT error_length CHECK (((char_length(last_error_message) <= 500) AND (char_length(last_error_backtrace) <= 10000))),
     CONSTRAINT job_class_length CHECK ((char_length(
 CASE job_class
@@ -98,7 +99,7 @@ WITH (fillfactor='90');
 -- Name: TABLE que_jobs; Type: COMMENT; Schema: public; Owner: -
 --
 
-COMMENT ON TABLE public.que_jobs IS '5';
+COMMENT ON TABLE public.que_jobs IS '7';
 
 
 --
@@ -1691,31 +1692,31 @@ CREATE INDEX que_jobs_data_gin_idx ON public.que_jobs USING gin (data jsonb_path
 
 
 --
+-- Name: que_jobs_kwargs_gin_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX que_jobs_kwargs_gin_idx ON public.que_jobs USING gin (kwargs jsonb_path_ops);
+
+
+--
 -- Name: que_poll_idx; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX que_poll_idx ON public.que_jobs USING btree (queue, priority, run_at, id) WHERE ((finished_at IS NULL) AND (expired_at IS NULL));
-
-
---
--- Name: que_poll_idx_with_job_schema_version; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX que_poll_idx_with_job_schema_version ON public.que_jobs USING btree (job_schema_version, queue, priority, run_at, id) WHERE ((finished_at IS NULL) AND (expired_at IS NULL));
+CREATE INDEX que_poll_idx ON public.que_jobs USING btree (job_schema_version, queue, priority, run_at, id) WHERE ((finished_at IS NULL) AND (expired_at IS NULL));
 
 
 --
 -- Name: que_jobs que_job_notify; Type: TRIGGER; Schema: public; Owner: -
 --
 
-CREATE TRIGGER que_job_notify AFTER INSERT ON public.que_jobs FOR EACH ROW EXECUTE FUNCTION public.que_job_notify();
+CREATE TRIGGER que_job_notify AFTER INSERT ON public.que_jobs FOR EACH ROW WHEN ((NOT (COALESCE(current_setting('que.skip_notify'::text, true), ''::text) = 'true'::text))) EXECUTE FUNCTION public.que_job_notify();
 
 
 --
 -- Name: que_jobs que_state_notify; Type: TRIGGER; Schema: public; Owner: -
 --
 
-CREATE TRIGGER que_state_notify AFTER INSERT OR DELETE OR UPDATE ON public.que_jobs FOR EACH ROW EXECUTE FUNCTION public.que_state_notify();
+CREATE TRIGGER que_state_notify AFTER INSERT OR DELETE OR UPDATE ON public.que_jobs FOR EACH ROW WHEN ((NOT (COALESCE(current_setting('que.skip_notify'::text, true), ''::text) = 'true'::text))) EXECUTE FUNCTION public.que_state_notify();
 
 
 --
@@ -1866,7 +1867,7 @@ ALTER TABLE ONLY public.products
 -- PostgreSQL database dump complete
 --
 
-\unrestrict HksAl2VB6bLjiIiZcjSaG8oUsAWODVCzXNE7H2fhkINcnKslGVTx2Q5ZRrBgxf6
+\unrestrict gDfLRO1DwcfZvR3rRAO6rhiY0ZxmG4IHbOjp6dJhW10CbQLnPVa4NtK9KQOfJZp
 
 SET search_path TO "$user", public;
 
@@ -1919,6 +1920,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20260731030708'),
 ('20260731030709'),
 ('20260731032000'),
-('20260731033000');
+('20260731033000'),
+('20260731034500');
 
 

--- a/test/jobs/que_enqueue_options_test.rb
+++ b/test/jobs/que_enqueue_options_test.rb
@@ -1,0 +1,20 @@
+require "test_helper"
+
+class QueEnqueueOptionsTest < ActiveSupport::TestCase
+  test "stores priority in job options instead of job arguments" do
+    job = ShrinkImageJob.enqueue(1, 2, job_options: { priority: 0 })
+
+    assert_equal 0, job.que_attrs[:priority]
+    assert_equal [1, 2], job.que_attrs[:args]
+    assert_equal({}, job.que_attrs[:kwargs])
+  end
+
+  test "stores a scheduled run time in job options" do
+    run_at = 4.hours.from_now
+    job = RemoveObsoleteMemberSessions.enqueue(job_options: { run_at: run_at })
+
+    assert_in_delta run_at.to_f, job.que_attrs[:run_at].to_f, 1.second
+    assert_equal [], job.que_attrs[:args]
+    assert_equal({}, job.que_attrs[:kwargs])
+  end
+end


### PR DESCRIPTION
## Summary

Upgrade Que from 1.3.1 to 2.4.1 and migrate its PostgreSQL schema to version 7.
Que 2 requires job settings to move below `job_options`, so priority and scheduled session-cleanup enqueues were updated.
The planned queue-drain window makes a direct schema upgrade appropriate.

## Validation

`RAILS_ENV=test bin/rails test` — 81 runs, 301 assertions; system tests excluded as requested.
`RAILS_ENV=test bin/rails db:migrate`