### PR TITLE
Upgrade Puma to 8.0

### DIFF
--- a/BUGS.md
+++ b/BUGS.md
@@ -1,0 +1,19 @@
+# Known bugs
+
+## Image upload fails for products and consumables
+
+Uploading an image in a product or consumable create/update action raises a
+`TypeError` when the action passes the result of `images.attach` to
+`Array#concat`.
+
+`images.attach` does not return an array of `ActiveStorage::Attachment`
+records. In Rails 7, it returns `true` when attaching to a persisted, unchanged
+record (because it saves immediately), and an
+`ActiveStorage::Attached::Changes::CreateMany` object when the record has
+pending changes. The attachment call must be separated from collecting the
+newly attached records for `ShrinkImageJob`.
+
+Affected code:
+
+- `ProductsController#create` and `#update`
+- `ConsumablesController#create` and `#update`

--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ gem 'rails', '~> 7.0.10'
 # Rails 7 no longer depends on Sprockets, but this application still uses it.
 gem 'sprockets-rails'
 gem 'pg'
-gem 'puma', '~> 3.11'
+gem 'puma', '~> 8.0'
 gem 'sass-rails', '~> 5.0'
 gem 'uglifier', '>= 1.3.0'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -216,7 +216,8 @@ GEM
     prawn-table (0.2.2)
       prawn (>= 1.3.0, < 3.0.0)
     public_suffix (7.0.5)
-    puma (3.12.6)
+    puma (8.0.2)
+      nio4r (~> 2.0)
     racc (1.8.1)
     rack (2.2.23)
     rack-test (2.2.0)
@@ -358,7 +359,7 @@ DEPENDENCIES
   pg
   prawn
   prawn-table
-  puma (~> 3.11)
+  puma (~> 8.0)
   que!
   rails (~> 7.0.10)
   rails-controller-testing

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -19,20 +19,16 @@ environment ENV.fetch("RAILS_ENV") { "development" }
 # Specifies the `pidfile` that Puma will use.
 pidfile ENV.fetch("PIDFILE") { "tmp/pids/server.pid" }
 
-# Specifies the number of `workers` to boot in clustered mode.
-# Workers are forked webserver processes. If using threads and workers together
-# the concurrency of the application would be max `threads` * `workers`.
-# Workers do not work on JRuby or Windows (both of which do not support
-# processes).
-#
-workers ENV.fetch("WEB_CONCURRENCY") { 2 }
-
-# Use the `preload_app!` method when specifying a `workers` number.
-# This directive tells Puma to first boot the application and load code
-# before forking the application. This takes advantage of Copy On Write
-# process behavior so workers use less memory.
-#
-preload_app!
+# Use clustered mode in environments that explicitly request multiple workers.
+# Otherwise Puma runs in single-process mode, which keeps local development
+# simple while retaining the configured thread pool above.
+web_concurrency = ENV.fetch("WEB_CONCURRENCY", 0).to_i
+if web_concurrency > 1
+  workers web_concurrency
+  preload_app!
+else
+  workers 0
+end
 
 # Allow puma to be restarted by `rails restart` command.
 plugin :tmp_restart


### PR DESCRIPTION
Upgrades Puma from 3.12.6 to 8.0.2 and locks its nio4r dependency. Keeps local development in Puma single mode while enabling preloaded clustered mode only when WEB_CONCURRENCY is greater than one. Adds a BUGS.md entry documenting the pre-existing Active Storage image-upload failure.