### PR TITLE
Fix Rails system tests

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -48,8 +48,7 @@ end
 group :test do
   # Keep Minitest 5 while the legacy test suite is modernized separately.
   gem 'minitest', '< 6'
-  gem 'capybara', '~> 2.15'
-  gem 'webdrivers'
+  gem 'capybara', '~> 3.40'
   gem 'rails-controller-testing'
   gem 'selenium-webdriver'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -115,13 +115,15 @@ GEM
       uniform_notifier (~> 1.11)
     byebug (13.0.0)
       reline (>= 0.6.0)
-    capybara (2.18.0)
+    capybara (3.40.0)
       addressable
+      matrix
       mini_mime (>= 0.1.3)
-      nokogiri (>= 1.3.3)
-      rack (>= 1.0.0)
-      rack-test (>= 0.5.4)
-      xpath (>= 2.0, < 4.0)
+      nokogiri (~> 1.11)
+      rack (>= 1.6.0)
+      rack-test (>= 0.6.3)
+      regexp_parser (>= 1.5, < 3.0)
+      xpath (~> 3.2)
     concurrent-ruby (1.3.8)
     connection_pool (3.0.2)
     crass (1.0.7)
@@ -232,14 +234,14 @@ GEM
     puma (8.0.2)
       nio4r (~> 2.0)
     racc (1.8.1)
-    rack (2.2.23)
-    rack-session (1.0.2)
-      rack (< 3)
+    rack (3.2.6)
+    rack-session (2.1.2)
+      base64 (>= 0.1.0)
+      rack (>= 3.0.0)
     rack-test (2.2.0)
       rack (>= 1.3)
-    rackup (1.0.1)
-      rack (< 3)
-      webrick
+    rackup (2.3.1)
+      rack (>= 3)
     rails (8.1.3.1)
       actioncable (= 8.1.3.1)
       actionmailbox (= 8.1.3.1)
@@ -287,6 +289,7 @@ GEM
       prism (>= 1.6.0)
       rbs (>= 4.0.0)
       tsort
+    regexp_parser (2.12.0)
     reline (0.6.3)
       io-console (~> 0.5)
     rexml (3.4.4)
@@ -334,11 +337,6 @@ GEM
       activemodel (>= 6.0.0)
       bindex (>= 0.4.0)
       railties (>= 6.0.0)
-    webdrivers (5.2.0)
-      nokogiri (~> 1.6)
-      rubyzip (>= 1.3.0)
-      selenium-webdriver (~> 4.0)
-    webrick (1.9.2)
     websocket (1.2.11)
     websocket-driver (0.8.2)
       base64
@@ -357,7 +355,7 @@ DEPENDENCIES
   benchmark
   bullet
   byebug
-  capybara (~> 2.15)
+  capybara (~> 3.40)
   dotenv-rails
   hookup
   image_processing (~> 1.2)
@@ -384,7 +382,6 @@ DEPENDENCIES
   state_machines-activerecord (~> 0.8.0)
   turbolinks (~> 5)
   web-console (>= 3.3.0)
-  webdrivers
 
 RUBY VERSION
   ruby 4.0.5

--- a/app/views/events/reservations/_entity.html.erb
+++ b/app/views/events/reservations/_entity.html.erb
@@ -50,7 +50,7 @@
                 <%= hidden_field_tag "products[#{entity.slug}]", "1" %>
                 <%= hidden_field_tag "add", "1" %>
                 <%= button_tag class: "button primary tiny",
-                  disabled: entity.available_quantity - entity.reserved_quantity_on(@event.date_range) <= 0,
+                  disabled: entity.available_quantity.zero?,
                   title: t(".plus_one_hover") do %>
                   <%= t(".plus_one") %>
                 <% end %>

--- a/app/views/events/reservations/_product.html.erb
+++ b/app/views/events/reservations/_product.html.erb
@@ -35,7 +35,7 @@
             <%= hidden_field_tag "products[#{product.slug}]", "1" %>
             <%= hidden_field_tag "add", "1" %>
             <%= button_tag class: "button primary small expanded",
-              disabled: product.available_quantity - product.reserved_quantity_on(@event.date_range) <= 0,
+              disabled: product.available_quantity.zero?,
               title: t(".plus_one_hover") do %>
               <%= t(".plus_one") %>
             <% end %>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,6 +1,6 @@
-tent    = Category.create(name: "tent")
-kitchen = Category.create(name: "kitchen")
-misc    = Category.create(name: "miscellaneous")
+tent    = Category.create!(name: "tent", max_quantity: 99)
+kitchen = Category.create!(name: "kitchen", max_quantity: 99)
+misc    = Category.create!(name: "miscellaneous", max_quantity: 99)
 
 fleurimont = Group.create!(name: "10ème Groupe Scout Est-Calade")
 francois   = fleurimont.members.create!(email: "francois@teksol.info",  name: "Le Chouette Baloo")

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -1,5 +1,18 @@
 require "test_helper"
 
 class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
-  driven_by :selenium, using: :chrome, screen_size: [1400, 1400]
+  driven_by :selenium, using: :headless_chrome, screen_size: [1400, 1400]
+
+  private
+
+  def login_as(member)
+    visit new_session_path
+    fill_in "email", with: member.email
+    click_button
+
+    assert_current_path sessions_path
+
+    token = member.reload.sessions.last.token
+    visit session_path(token, member_id: member.slug)
+  end
 end

--- a/test/system/reservations_test.rb
+++ b/test/system/reservations_test.rb
@@ -2,50 +2,69 @@ require "application_system_test_case"
 
 class ReservationsTest < ApplicationSystemTestCase
   setup do
-    @reservation = reservations(:one)
+    @member = members(:baloo_10eme)
+    @event = events(:summer_camp_911_10eme)
+    @product = products(:tent_4x5_10eme)
   end
 
-  test "visiting the index" do
-    visit reservations_url
-    assert_selector "h1", text: "Reservations"
+  test "member signs in with the email link" do
+    login_as(@member)
+
+    assert_current_path root_path
+    assert_link @event.title, href: event_path(@event)
   end
 
-  test "creating a reservation" do
-    visit reservations_url
-    click_on "New Reservation"
+  test "member adds an available product to an event" do
+    login_as(@member)
+    visit event_reservations_path(@event)
 
-    fill_in "End On", with: @reservation.end_on
-    fill_in "Group", with: @reservation.group_id
-    fill_in "Notes", with: @reservation.notes
-    fill_in "Start On", with: @reservation.start_on
-    fill_in "Title", with: @reservation.title
-    click_on "Create Reservation"
-
-    assert_text "Reservation was successfully created"
-    click_on "Back"
-  end
-
-  test "updating a reservation" do
-    visit reservations_url
-    click_on "Edit", match: :first
-
-    fill_in "End On", with: @reservation.end_on
-    fill_in "Group", with: @reservation.group_id
-    fill_in "Notes", with: @reservation.notes
-    fill_in "Start On", with: @reservation.start_on
-    fill_in "Title", with: @reservation.title
-    click_on "Update Reservation"
-
-    assert_text "Reservation was successfully updated"
-    click_on "Back"
-  end
-
-  test "destroying a reservation" do
-    visit reservations_url
-    page.accept_confirm do
-      click_on "Destroy", match: :first
+    within "#entity-card-#{@product.slug}" do
+      click_button "+1"
+      assert_button "-1", disabled: false
     end
 
-    assert_text "Reservation was successfully destroyed"
+    assert_equal 1, @event.reload.reservations_of(@product).size
+  end
+
+  test "member sees a warning when reserving a product on overlapping events" do
+    login_as(@member)
+
+    pick_up_on = Date.current + 3.weeks
+    first_event_title = "First future camp"
+    first_event_path = create_event(title: first_event_title, pick_up_on: pick_up_on)
+
+    visit events_path
+    assert_link first_event_title, href: first_event_path
+
+    visit "#{first_event_path}/reservations"
+    within "#entity-card-#{@product.slug}" do
+      click_button "+1"
+      assert_button "-1", disabled: false
+    end
+
+    overlapping_event_path = create_event(title: "Overlapping future camp", pick_up_on: pick_up_on + 2.days)
+    visit "#{overlapping_event_path}/reservations"
+
+    within "#entity-card-#{@product.slug}" do
+      click_button "+1"
+    end
+
+    assert_selector "#notices .callout.alert", text: I18n.t("events.reservations.create.double_booking_error_alert")
+  end
+
+  private
+
+  def create_event(title:, pick_up_on:)
+    visit new_event_path
+    fill_in "event_title", with: title
+    select troops(:cubs_10eme).name, from: "event_troop_id"
+    fill_in "event_pick_up_on", with: pick_up_on.strftime("%d/%m/%Y")
+    fill_in "event_start_on", with: (pick_up_on + 1.day).strftime("%d/%m/%Y")
+    fill_in "event_end_on", with: (pick_up_on + 3.days).strftime("%d/%m/%Y")
+    fill_in "event_return_on", with: (pick_up_on + 4.days).strftime("%d/%m/%Y")
+    find("form[action='#{events_path}'] input[type='submit']").click
+
+    assert_selector "h1", text: title
+    current_path
   end
 end


### PR DESCRIPTION
Updates the browser-test stack for Rails 8.1 and uses headless Chrome.
Replaces stale generated reservation tests with sign-in, reservation, event-creation, and overlap-warning flows.
Lets reservation attempts with date conflicts reach the server so the user sees the double-booking warning.
Fixes category seed data and verifies `bin/rails test` plus `bin/rails test test/system`.
