### PR TITLE
Fix product and consumable image attachments

### DIFF
--- a/app/controllers/consumables/images_controller.rb
+++ b/app/controllers/consumables/images_controller.rb
@@ -50,7 +50,7 @@ class Consumables::ImagesController < ApplicationController
       img.write(updname)
 
       File.open(updname, "r:ASCII-8BIT") do |io|
-        @new_image = @consumable.images.attach(io: io, filename: @image.filename).first
+        @new_image = @consumable.images.attach(io: io, filename: @image.filename).last
       end
       @image.destroy
 

--- a/app/controllers/consumables_controller.rb
+++ b/app/controllers/consumables_controller.rb
@@ -51,7 +51,7 @@ class ConsumablesController < ApplicationController
       @consumable = current_group.register_new_consumable(consumable_params, metadata: domain_event_metadata)
 
       @attached = []
-      @attached.concat(@consumable.images.attach(params[:consumable][:images])) if params[:consumable][:images].present?
+      @attached.concat(attach_images(params[:consumable][:images]))
       @attached.concat(import(params[:consumable][:image_url]))
 
       if params[:clone_from].present?
@@ -81,7 +81,7 @@ class ConsumablesController < ApplicationController
       @consumable.change_data(consumable_params, metadata: domain_event_metadata)
 
       @attached = []
-      @attached.concat(@consumable.images.attach(params[:consumable][:images])) if params[:consumable][:images].present?
+      @attached.concat(attach_images(params[:consumable][:images]))
       @attached.concat(import(params[:consumable][:image_url]))
 
       @consumable.save.tap do
@@ -138,10 +138,17 @@ class ConsumablesController < ApplicationController
 
     response = Net::HTTP.get_response(uri)
 
-    @consumable.images.attach(
+    attach_images(
       io: StringIO.new(response.body),
       filename: File.basename(uri.path),
       content_type: response["Content-Type"],
     )
+  end
+
+  def attach_images(attachables)
+    attachables = Array.wrap(attachables).compact_blank
+    return [] if attachables.empty?
+
+    @consumable.images.attach(attachables).last(attachables.size)
   end
 end

--- a/app/controllers/entities/images_controller.rb
+++ b/app/controllers/entities/images_controller.rb
@@ -51,7 +51,7 @@ class Entities::ImagesController < ApplicationController
       img.write(updname)
 
       File.open(updname, "r:ASCII-8BIT") do |io|
-        @new_image = @entity.images.attach(io: io, filename: @image.filename).first
+        @new_image = @entity.images.attach(io: io, filename: @image.filename).last
       end
       @image.destroy
 

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -51,7 +51,7 @@ class ProductsController < ApplicationController
       @product = current_group.register_new_product(product_params, metadata: domain_event_metadata)
 
       @attached = []
-      @attached.concat(@product.images.attach(params[:product][:images])) if params[:product][:images].present?
+      @attached.concat(attach_images(params[:product][:images]))
       @attached.concat(import(params[:product][:image_url]))
 
       if params[:clone_from].present?
@@ -81,7 +81,7 @@ class ProductsController < ApplicationController
       @product.change_data(product_params, metadata: domain_event_metadata)
 
       @attached = []
-      @attached.concat(@product.images.attach(params[:product][:images])) if params[:product][:images].present?
+      @attached.concat(attach_images(params[:product][:images]))
       @attached.concat(import(params[:product][:image_url]))
 
       @product.save.tap do
@@ -150,10 +150,17 @@ class ProductsController < ApplicationController
 
     response = Net::HTTP.get_response(uri)
 
-    @product.images.attach(
+    attach_images(
       io: StringIO.new(response.body),
       filename: File.basename(uri.path),
       content_type: response["Content-Type"],
     )
+  end
+
+  def attach_images(attachables)
+    attachables = Array.wrap(attachables).compact_blank
+    return [] if attachables.empty?
+
+    @product.images.attach(attachables).last(attachables.size)
   end
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -31,6 +31,7 @@ Rails.application.configure do
 
   # Store uploaded files on the local file system in a temporary directory
   config.active_storage.service = :test
+  config.active_storage.variant_processor = :mini_magick
 
   config.action_mailer.perform_caching = false
 

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -3,6 +3,14 @@ require "test_helper"
 class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
   driven_by :selenium, using: :headless_chrome, screen_size: [1400, 1400]
 
+  setup do
+    @system_test_images = []
+  end
+
+  teardown do
+    @system_test_images.each { |path| File.delete(path) if File.exist?(path) }
+  end
+
   private
 
   def login_as(member)
@@ -14,5 +22,17 @@ class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
 
     token = member.reload.sessions.last.token
     visit session_path(token, member_id: member.slug)
+  end
+
+  def image_file(width:, height:, color:)
+    Rails.root.join("tmp", "system-test-image-#{SecureRandom.uuid}.jpg").tap do |path|
+      MiniMagick.convert do |convert|
+        convert.size "#{width}x#{height}"
+        convert.xc color
+        convert << path
+      end
+
+      @system_test_images << path
+    end
   end
 end

--- a/test/system/consumables_test.rb
+++ b/test/system/consumables_test.rb
@@ -1,0 +1,49 @@
+require "application_system_test_case"
+
+class ConsumablesTest < ApplicationSystemTestCase
+  setup do
+    @member = members(:akela_10eme)
+  end
+
+  test "inventory director adds a consumable image and rotates it" do
+    create_consumable(
+      name: "Portrait image consumable",
+      images: [image_file(width: 20, height: 30, color: "red")],
+    )
+
+    assert_selector ".entity-image", count: 1
+    image_card_id = find(".entity-image")[:id]
+
+    within "##{image_card_id}" do
+      find("form[action$='/right'] button").click
+    end
+
+    assert_no_selector "##{image_card_id}"
+    assert_selector ".entity-image", count: 1
+    refute_equal image_card_id, find(".entity-image")[:id]
+  end
+
+  test "inventory director adds several consumable images at once" do
+    create_consumable(
+      name: "Multiple images consumable",
+      images: [
+        image_file(width: 20, height: 30, color: "red"),
+        image_file(width: 30, height: 20, color: "blue"),
+      ],
+    )
+
+    assert_selector ".entity-image", count: 2
+  end
+
+  private
+
+  def create_consumable(name:, images:)
+    login_as(@member)
+    visit new_consumable_path
+
+    fill_in "consumable_name", with: name
+    fill_in "consumable_base_quantity", with: "1 unit"
+    attach_file "consumable_images", images
+    click_button I18n.t("helpers.submit.create", model: Consumable.model_name.human)
+  end
+end

--- a/test/system/products_test.rb
+++ b/test/system/products_test.rb
@@ -1,0 +1,43 @@
+require "application_system_test_case"
+
+class ProductsTest < ApplicationSystemTestCase
+  setup do
+    @member = members(:akela_10eme)
+  end
+
+  test "inventory director adds a product image and rotates it" do
+    login_as(@member)
+    visit new_product_path
+
+    fill_in "product_name", with: "Portrait image product"
+    fill_in "product_quantity", with: 1
+    attach_file "product_images", image_file(width: 20, height: 30, color: "red")
+    click_button I18n.t("helpers.submit.create", model: Product.model_name.human)
+
+    assert_selector ".entity-image", count: 1
+    image_card_id = find(".entity-image")[:id]
+
+    within "##{image_card_id}" do
+      find("form[action$='/right'] button").click
+    end
+
+    assert_no_selector "##{image_card_id}"
+    assert_selector ".entity-image", count: 1
+    refute_equal image_card_id, find(".entity-image")[:id]
+  end
+
+  test "inventory director adds several product images at once" do
+    login_as(@member)
+    visit new_product_path
+
+    fill_in "product_name", with: "Multiple images product"
+    fill_in "product_quantity", with: 1
+    attach_file "product_images", [
+      image_file(width: 20, height: 30, color: "red"),
+      image_file(width: 30, height: 20, color: "blue"),
+    ]
+    click_button I18n.t("helpers.submit.create", model: Product.model_name.human)
+
+    assert_selector ".entity-image", count: 2
+  end
+end


### PR DESCRIPTION
Fixes image rotation so the newly attached record replaces the old one.

Captures only newly attached images when uploads contain one or more files, so existing images do not get queued again.

Adds browser coverage for rotation and multi-image uploads for products and consumables, and uses MiniMagick for test variants.

Validated with `bundle exec rails test test/system/products_test.rb test/system/consumables_test.rb`.