### PR TITLE
Migrate image processing to Vips

### DIFF
--- a/app/controllers/concerns/sanitizes_images.rb
+++ b/app/controllers/concerns/sanitizes_images.rb
@@ -1,0 +1,23 @@
+module SanitizesImages
+  private
+
+  def sanitize_images(attachables)
+    Array.wrap(attachables).compact_blank.map do |attachable|
+      sanitize_image(attachable)
+    end
+  end
+
+  def sanitize_image(attachable)
+    sanitized = ImageSanitizer.call(attachable)
+    sanitized_images << sanitized
+    sanitized
+  end
+
+  def close_sanitized_images
+    sanitized_images.each { |image| image.fetch(:io).close! }
+  end
+
+  def sanitized_images
+    @sanitized_images ||= []
+  end
+end

--- a/app/controllers/consumables_controller.rb
+++ b/app/controllers/consumables_controller.rb
@@ -1,4 +1,6 @@
 class ConsumablesController < ApplicationController
+  include SanitizesImages
+
   before_action :set_consumable, only: [:show, :edit, :update, :destroy]
   before_action :load_categories, except: %i[ destroy ]
 
@@ -74,6 +76,12 @@ class ConsumablesController < ApplicationController
       @page_title = "New Consumable"
       render :new
     end
+  rescue ImageSanitizer::Error
+    @consumable.errors.add(:images, :unsupported_image)
+    @page_title = "New Consumable"
+    render :new, status: :unprocessable_content
+  ensure
+    close_sanitized_images
   end
 
   def update
@@ -97,6 +105,12 @@ class ConsumablesController < ApplicationController
       @page_title = "Edit #{@consumable.name}"
       render :edit
     end
+  rescue ImageSanitizer::Error
+    @consumable.errors.add(:images, :unsupported_image)
+    @page_title = "Edit #{@consumable.name}"
+    render :edit, status: :unprocessable_content
+  ensure
+    close_sanitized_images
   end
 
   def destroy
@@ -146,9 +160,9 @@ class ConsumablesController < ApplicationController
   end
 
   def attach_images(attachables)
-    attachables = Array.wrap(attachables).compact_blank
-    return [] if attachables.empty?
+    sanitized = sanitize_images(attachables)
+    return [] if sanitized.empty?
 
-    @consumable.images.attach(attachables).last(attachables.size)
+    @consumable.images.attach(sanitized).last(sanitized.size)
   end
 end

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -1,4 +1,6 @@
 class GroupsController < ApplicationController
+  include SanitizesImages
+
   before_action :set_group, only: [:show, :edit, :update, :destroy]
 
   def index
@@ -33,6 +35,13 @@ class GroupsController < ApplicationController
       @page_title = t(".page_title")
       render :new
     end
+  rescue ImageSanitizer::Error
+    @group ||= Group.new
+    @group.errors.add(:logo, :unsupported_image)
+    @page_title = t(".page_title")
+    render :new, status: :unprocessable_content
+  ensure
+    close_sanitized_images
   end
 
   def update
@@ -42,6 +51,12 @@ class GroupsController < ApplicationController
       @page_title = t(".page_title", group_name: @group.name)
       render :edit
     end
+  rescue ImageSanitizer::Error
+    @group.errors.add(:logo, :unsupported_image)
+    @page_title = t(".page_title", group_name: @group.name)
+    render :edit, status: :unprocessable_content
+  ensure
+    close_sanitized_images
   end
 
   def destroy
@@ -58,6 +73,8 @@ class GroupsController < ApplicationController
   end
 
   def group_params
-    params.require(:group).permit(:name, :logo, :address)
+    permitted = params.require(:group).permit(:name, :logo, :address)
+    permitted[:logo] = sanitize_image(permitted[:logo]) if permitted[:logo].present?
+    permitted
   end
 end

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -19,7 +19,8 @@ class HomeController < PublicController
     return render file: "public/404.html", status: :bad_request unless VALID_SIZES.include?(params[:size])
 
     if current_group && current_group.logo.attached?
-      redirect_to url_for(current_group.logo.variant(resize: params[:size]))
+      width, height = params[:size].split("x").map(&:to_i)
+      redirect_to url_for(current_group.logo.variant(resize_to_limit: [ width, height ]))
     else
       render file: "public/404.html", status: :not_found
     end

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -1,4 +1,6 @@
 class ProductsController < ApplicationController
+  include SanitizesImages
+
   before_action :set_product, only: [:show, :edit, :update, :destroy, :convert]
   before_action :load_categories, except: %i[ destroy ]
 
@@ -74,6 +76,12 @@ class ProductsController < ApplicationController
       @page_title = "New Product"
       render :new
     end
+  rescue ImageSanitizer::Error
+    @product.errors.add(:images, :unsupported_image)
+    @page_title = "New Product"
+    render :new, status: :unprocessable_content
+  ensure
+    close_sanitized_images
   end
 
   def update
@@ -97,6 +105,12 @@ class ProductsController < ApplicationController
       @page_title = "Edit #{@product.name}"
       render :edit
     end
+  rescue ImageSanitizer::Error
+    @product.errors.add(:images, :unsupported_image)
+    @page_title = "Edit #{@product.name}"
+    render :edit, status: :unprocessable_content
+  ensure
+    close_sanitized_images
   end
 
   def destroy
@@ -158,9 +172,9 @@ class ProductsController < ApplicationController
   end
 
   def attach_images(attachables)
-    attachables = Array.wrap(attachables).compact_blank
-    return [] if attachables.empty?
+    sanitized = sanitize_images(attachables)
+    return [] if sanitized.empty?
 
-    @product.images.attach(attachables).last(attachables.size)
+    @product.images.attach(sanitized).last(sanitized.size)
   end
 end

--- a/app/helpers/entity_helper.rb
+++ b/app/helpers/entity_helper.rb
@@ -2,7 +2,7 @@ module EntityHelper
   def entity_image(entity, height: 250)
     if image = entity.images.first
       if image.blob && image.variable?
-        return link_to(image_tag(image.variant(WEB_IMAGE_CONFIG.merge(resize: "x#{height}")), height: height, alt: "", class: "entity-image"), entity, class: "float-center")
+        return link_to(image_tag(image.variant(WEB_IMAGE_CONFIG.merge(resize_to_limit: [ nil, height ])), height: height, alt: "", class: "entity-image"), entity, class: "float-center")
       end
     end
 

--- a/app/jobs/shrink_image_job.rb
+++ b/app/jobs/shrink_image_job.rb
@@ -9,13 +9,13 @@ class ShrinkImageJob < ApplicationJob
       image.variant(WEB_IMAGE_CONFIG).processed
 
       logger.info "Creating smallest thumbnail"
-      image.variant(WEB_IMAGE_CONFIG.merge(resize: "x100")).processed
+      image.variant(WEB_IMAGE_CONFIG.merge(resize_to_limit: [ nil, 100 ])).processed
 
       logger.info "Creating medium thumbnail"
-      image.variant(WEB_IMAGE_CONFIG.merge(resize: "x250")).processed
+      image.variant(WEB_IMAGE_CONFIG.merge(resize_to_limit: [ nil, 250 ])).processed
 
       logger.info "Creating largest thumbnail"
-      image.variant(WEB_IMAGE_CONFIG.merge(resize: "300x225")).processed
+      image.variant(WEB_IMAGE_CONFIG.merge(resize_to_limit: [ 300, 225 ])).processed
     end
   end
 end

--- a/app/services/image_sanitizer.rb
+++ b/app/services/image_sanitizer.rb
@@ -1,0 +1,70 @@
+require "tempfile"
+
+class ImageSanitizer
+  class Error < StandardError; end
+
+  FORMATS = {
+    "image/jpeg" => { format: :jpeg, extension: "jpg" },
+    "image/png" => { format: :png, extension: "png" },
+    "image/webp" => { format: :webp, extension: "webp" },
+  }.freeze
+
+  def self.call(attachable)
+    new(attachable).call
+  end
+
+  def initialize(attachable)
+    @attachable = attachable
+  end
+
+  def call
+    input = copy_input_to_tempfile
+    content_type = Marcel::MimeType.for(input, name: filename)
+    format = FORMATS.fetch(content_type) do
+      raise Error, "unsupported image format"
+    end
+
+    output = ImageProcessing::Vips
+      .source(input)
+      .convert(format.fetch(:format))
+      .saver(strip: true, quality: 80)
+      .call
+
+    {
+      io: output,
+      filename: "#{basename}.#{format.fetch(:extension)}",
+      content_type: content_type,
+    }
+  rescue Vips::Error, ImageProcessing::Error => error
+    raise Error, error.message
+  ensure
+    input&.close!
+  end
+
+  private
+
+  def copy_input_to_tempfile
+    tempfile = Tempfile.new([ "image-upload", File.extname(filename) ], binmode: true)
+    source = input_io
+    source.rewind if source.respond_to?(:rewind)
+    IO.copy_stream(source, tempfile)
+    tempfile.rewind
+    tempfile
+  end
+
+  def input_io
+    return @attachable.tempfile if @attachable.respond_to?(:tempfile)
+
+    @attachable.fetch(:io)
+  end
+
+  def filename
+    return @attachable.original_filename if @attachable.respond_to?(:original_filename)
+
+    @attachable.fetch(:filename)
+  end
+
+  def basename
+    File.basename(filename, File.extname(filename)).presence || "image"
+  end
+end

--- a/app/views/groups/show.html.erb
+++ b/app/views/groups/show.html.erb
@@ -5,7 +5,7 @@
 
     <h2>
       <% if @group.logo.attached? %>
-        <%= image_tag @group.logo.variant(resize: "x55"), alt: "", height: 55, style: "max-height: 55px" %>
+        <%= image_tag @group.logo.variant(resize_to_limit: [ nil, 55 ]), alt: "", height: 55, style: "max-height: 55px" %>
       <% end %>
       <%= t(".members") %>
     </h2>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -46,7 +46,7 @@
             <li class="<%= :active if on_groups_page? %>">
               <%= link_to  current_group do %>
                 <% if current_group.logo.attached? %>
-                  <%= image_tag current_group.logo.variant(resize: "x15"), alt: "", height: 15, style: "max-height: 15px" %>
+                  <%= image_tag current_group.logo.variant(resize_to_limit: [ nil, 15 ]), alt: "", height: 15, style: "max-height: 15px" %>
                 <% end %>
                 <%= truncate(current_group.name, length: 30) %>
               <% end %>

--- a/app/views/shared/_image.html.erb
+++ b/app/views/shared/_image.html.erb
@@ -1,6 +1,6 @@
 <div class="cell entity-image" id="entity-<%= entity.slug %>-image-<%= image.id %>">
   <div class="card">
-    <%= link_to image_tag(image.variant(WEB_IMAGE_CONFIG.merge(resize: "300x225")), alt: "", size: "300x225"), image, class: "thumbnail" %>
+    <%= link_to image_tag(image.variant(WEB_IMAGE_CONFIG.merge(resize_to_limit: [ 300, 225 ])), alt: "", size: "300x225"), image, class: "thumbnail" %>
     <% if current_member.inventory_director?  %>
       <div class="card-section">
         <div class="grid-x grid-margin-x">

--- a/config/application.rb
+++ b/config/application.rb
@@ -9,9 +9,11 @@ Bundler.require(*Rails.groups)
 STAGING = ENV.fetch("STAGING", "false") == "true"
 
 WEB_IMAGE_CONFIG = {
-  strip: true,
-  quality: 80,
-  resize: 1200,
+  resize_to_limit: [ 1200, 1200 ],
+  saver: {
+    strip: true,
+    quality: 80,
+  },
 }
 
 module Scoutinv

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,4 +1,7 @@
 en:
+  errors:
+    messages:
+      unsupported_image: must be a JPEG, PNG, or WebP image
   activerecord:
     models:
       event: Event

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1,4 +1,7 @@
 fr:
+  errors:
+    messages:
+      unsupported_image: doit être une image JPEG, PNG ou WebP
   activerecord:
     models:
       event: Événement

--- a/test/services/image_sanitizer_test.rb
+++ b/test/services/image_sanitizer_test.rb
@@ -1,0 +1,42 @@
+require "test_helper"
+require "base64"
+require "stringio"
+
+class ImageSanitizerTest < ActiveSupport::TestCase
+  ORIENTED_JPEG = <<~BASE64.delete("\n")
+    /9j/4AAQSkZJRgABAQAAGQAZAAD/4QCwRXhpZgAATU0AKgAAAAgABQESAAMAAAABAAYAAAEaAAUAAAAB
+    AAAASgEbAAUAAAABAAAAUgEoAAMAAAABAAIAAIdpAAQAAAABAAAAWgAAAAAAAAB/AAAABQAAAH8AAAAF
+    AAaQAAAHAAAABDAyMTCRAQAHAAAABAECAwCgAAAHAAAABDAxMDCgAQADAAAAAQABAACgAgAEAAAAAQAA
+    AASgAwAEAAAAAQAAAAIAAAAA/+0AOFBob3Rvc2hvcCAzLjAAOEJJTQQEAAAAAAAAOEJJTQQlAAAAAAAQ
+    1B2M2Y8AsgTpgAmY7PhCfv/AABEIAAIABAMBIgACEQEDEQH/xAAfAAABBQEBAQEBAQAAAAAAAAAAAQID
+    BAUGBwgJCgv/xAC1EAACAQMDAgQDBQUEBAAAAX0BAgMABBEFEiExQQYTUWEHInEUMoGRoQgjQrHBFVLR
+    8CQzYnKCCQoWFxgZGiUmJygpKjQ1Njc4OTpDREVGR0hJSlNUVVZXWFlaY2RlZmdoaWpzdHV2d3h5eoOE
+    hYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3uLm6wsPExcbHyMnK0tPU1dbX2Nna4eLj5OXm5+jp
+    6vHy8/T19vf4+fr/xAAfAQADAQEBAQEBAQEBAAAAAAAAAQIDBAUGBwgJCgv/xAC1EQACAQIEBAMEBwUE
+    BAABAncAAQIDEQQFITEGEkFRB2FxEyIygQgUQpGhscEJIzNS8BVictEKFiQ04SXxFxgZGiYnKCkqNTY3
+    ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqCg4SFhoeIiYqSk5SVlpeYmZqio6Slpqeo
+    qaqys7S1tre4ubrCw8TFxsfIycrS09TV1tfY2dri4+Tl5ufo6ery8/T19vf4+fr/2wBDAAICAgICAgMC
+    AgMFAwMDBQYFBQUFBggGBgYGBggKCAgICAgICgoKCgoKCgoMDAwMDAwODg4ODg8PDw8PDw8PDw//2wBD
+    AQICAgQEBAcEBAcQCwkLEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQ
+    EBAQEBD/3QAEAAH/2gAMAwEAAhEDEQA/APi+iiiv5TP9/D//2Q==
+  BASE64
+
+  test "applies orientation and removes EXIF metadata" do
+    source = Vips::Image.new_from_buffer(Base64.strict_decode64(ORIENTED_JPEG), "")
+    sanitized = ImageSanitizer.call(
+      io: StringIO.new(Base64.strict_decode64(ORIENTED_JPEG)),
+      filename: "oriented.jpg",
+    )
+
+    image = Vips::Image.new_from_file(sanitized.fetch(:io).path)
+
+    assert_includes source.get_fields, "exif-ifd0-Orientation"
+    assert_equal "image/jpeg", sanitized.fetch(:content_type)
+    assert_equal "oriented.jpg", sanitized.fetch(:filename)
+    assert_equal 2, image.width
+    assert_equal 4, image.height
+    assert_empty image.get_fields.grep(/exif|orientation/i)
+  ensure
+    sanitized&.fetch(:io)&.close!
+  end
+end


### PR DESCRIPTION
Migrates image variants to Vips-safe resize and saver options, including product images and group logos.

Sanitizes new product, consumable, URL-imported, and logo uploads by applying orientation to pixels and stripping metadata before storage.

This fixes the Vips 500 errors caused by MiniMagick-specific `resize`, `strip`, and `quality` options, while preventing EXIF metadata from reaching new stored blobs.

Validated with focused Rails tests, an EXIF-orientation sanitizer test, a real PNG sanitizer run, and `bin/rails zeitwerk:check`.