### PR TITLE
Add Scoutinv brand and marketing guidelines

### DIFF
--- a/doc/branding-guidelines.md
+++ b/doc/branding-guidelines.md
@@ -1,0 +1,128 @@
+# Scoutinv Brand Identity Guidelines
+
+## Purpose
+
+This document defines Scoutinv's proposed brand identity. It is the reference for anyone designing or implementing the interface, marketing site, email, and product documents.
+
+These guidelines are self-contained. The signed-in application should reuse this system without turning every screen into a newspaper page.
+
+## Core idea
+
+Scoutinv is not an abstract “inventory management” product. It helps a group retain the memory of its equipment: what leaves for an adventure, what returns, what needs checking or repair, and what the next equipment volunteers need to know.
+
+The identity should convey:
+
+- the calm confidence of a well-kept notebook;
+- the field and the real life of equipment;
+- continuity between volunteers;
+- care for shared objects;
+- open-source software that is clear and trustworthy.
+
+It must not feel like an aggressive SaaS startup, a military tool, or a generic camping application.
+
+## Editorial voice
+
+Prefer concrete, human facts: a tent, a door, an outing, a return, a person taking over. The benefit should emerge from the situation rather than from an abstract marketing promise.
+
+Prefer:
+
+- “Your equipment goes on adventures. Keep track of its return.”
+- “Sarah hands the equipment over to Martin.”
+- “A problem was reported with the tent door.”
+- “Prepare. Leave. Return.”
+
+Avoid:
+
+- “Optimize your inventory flows.”
+- “The all-in-one platform that revolutionizes your logistics.”
+- inflated quantities or screenshots that claim to represent the actual product.
+
+Serial numbers are real identifiers: `MJ9`, `N8C`, and `D81` identify one specific item among several otherwise similar objects. Write them as concrete data, never as decorative codes.
+
+## Colour palette
+
+Use semantic names in code rather than colour names.
+
+| Token | Value | Role | Intended feeling |
+| --- | --- | --- | --- |
+| `--paper` | `#f5eee2` | Main background | Paper, archive, warmth, longevity |
+| `--surface` | `#fffdf8` | Cards and raised backgrounds | Clean, readable, breathable page |
+| `--ink` | `#263a56` | Text, rules, structure | Newspaper ink, precision, trust |
+| `--action` | `#bd513e` | Primary action and occasional accent | Terracotta, human gesture, action |
+| `--sage` | `#b8d3be` | Calm status, equipment sheet, secondary background | Maintenance, attention, living equipment |
+| `--field` | `#639078` | Illustration and mid-green accent | Field, outdoors, real use |
+| `--forest` | `#192d28` | Dark panels and contrast | Solidity, workshop, reliability |
+
+Rules:
+
+- `--ink` replaces pure black for text and rules. Do not add decorative `#000`.
+- `--action` is rare and intentional: the primary CTA, a small brand accent, or a state that needs attention. It must not become a second dominant background.
+- The greens are not three competing CTA colours. They communicate field work, state, and maintenance.
+- Keep `--paper` as the dominant background and `--surface` as gentle contrast; the interface must not become a mosaic of coloured panels.
+- Test every foreground/background combination for WCAG AA contrast before shipping.
+
+## Typography
+
+Limit the final system to three families.
+
+| Family | Use | Why |
+| --- | --- | --- |
+| Newsreader | Editorial and major section headings | A contemporary, human, memorable newspaper voice |
+| DM Sans | Interface, navigation, body text, fields, and buttons | Clear, warm reading without a technocratic feel |
+| DM Mono | Metadata and technical markers | Recalls physical labels, serial numbers, and equipment sheets |
+
+### Scale and styles
+
+| Use | Family / weight | Target size | Leading / spacing |
+| --- | --- | --- | --- |
+| Marketing manifesto title | Newsreader 600 | `clamp(3rem, 7vw, 6.6rem)` | `0.9–0.95`, tracking `-0.05em` to `-0.065em` |
+| Application H1 | Newsreader 600 | 2.5–3.25 rem | 1.0 |
+| Section H2 | Newsreader 600 | 2–3 rem | 0.95–1.0 |
+| H3 / card title | DM Sans 700 | 1.1–1.4 rem | 1.15 |
+| Body text | DM Sans 400 | 1 rem / 16 px | 1.45–1.6 |
+| Button | DM Sans 700 | 0.875–1 rem | 1 |
+| Actual form `<label>` | DM Sans 600 | 0.875 rem | normal |
+| Editorial eyebrow, serial number, state, date | DM Mono 400 or 500 | 0.66–0.75 rem | optional capitals, `0.05–0.08em` |
+
+Monospace is not for long text or actual form labels. It makes a data point instantly scannable: `S/N · MJ9`, `UNDER REPAIR`, a date, or a location.
+
+### Font loading
+
+DM Sans, DM Mono, and Newsreader are not reliable system fonts. Host them in Scoutinv's assets with `@font-face`; do not depend on Google Fonts in production. Use these fallbacks:
+
+```css
+font-family: "Newsreader", Georgia, serif;
+font-family: "DM Sans", system-ui, sans-serif;
+font-family: "DM Mono", ui-monospace, SFMono-Regular, Menlo, monospace;
+```
+
+Declare `font-display: swap` and include the weights actually used: Newsreader 600, DM Sans 400/600/700, and DM Mono 400/500.
+
+## Logo and graphic marks
+
+The proposed wordmark is `Scoutinv`:
+
+- “Scout” uses `--forest` or `--ink`;
+- “inv” uses `--action`;
+- DM Sans 800 with slightly tight tracking;
+- do not add a compass, tent, or fleur-de-lis icon by default.
+
+For production, create a final logo SVG rather than recreating the wordmark in HTML in every view.
+
+## Motifs and imagery
+
+Useful motifs are editorial: fine rules, newspaper double rules, columns, sheet labels, and large serial numbers. They must support information, never become decorative noise.
+
+Images should show an object, its use, or its real condition: an identified tent, a zipper, an axe, a stove, or a storage shelf. Avoid generic stock photos of smiling young people around a fire: they do not explain what Scoutinv does.
+
+## Interface principles
+
+- Readability takes precedence over editorial flourish on working screens.
+- Use Newsreader to give important titles personality, not for tables, forms, or repeated actions.
+- Name actions with verbs: “Register my group”, “Send”, “Mark for repair”, “Confirm return”.
+- Keep equipment state and serial number close together; users should not need to open a detail page to identify an item.
+- On mobile, turn columns into a vertical sequence with clear separators.
+
+## Implementation direction
+
+Build the final system from semantic design tokens and reusable components. Do not encode visual directions as numbered page classes; production CSS should expose intentional tokens, typography styles, and component classes instead.

--- a/doc/marketing-guidelines.md
+++ b/doc/marketing-guidelines.md
@@ -1,0 +1,205 @@
+# Scoutinv Landing Page Specification
+
+## Goal
+
+This page serves people who are not signed in. Its goal is to explain Scoutinv, build trust in its approach, and lead visitors to register or sign in.
+
+The page is not a product screenshot. It is a Gazette: an editorial page that tells the story of equipment and demonstrates product benefits through concrete situations.
+
+## Rails implementation constraints
+
+- Create a separate marketing layout for the anonymous home page. The current layout includes a Foundation top bar, generic H1, and footer that conflict with this composition.
+- Keep the application layout for signed-in users until the design system migration is complete.
+- Convert static CTAs into real actions: registration must lead to the registration form; sign-in must lead to the email-link form already used by the app.
+- Put every visible string in `fr.yml` and `en.yml`.
+- Host the three font families in the asset pipeline and load them with `@font-face`.
+- Do not use a Google Fonts `@import` in production.
+
+## Container and responsive behaviour
+
+| Element | Reference value |
+| --- | --- |
+| Content width | `min(1160px, calc(100% - 48px))` |
+| Page background | `--paper` (`#f5eee2`) |
+| Rules | 1 px `--ink`; 3 px double rule for header/footer |
+| Desktop columns | CSS Grid with no gap; borders separate columns |
+| Breakpoint | 720 px reference; 768 px is acceptable if used consistently in the app |
+| Mobile | Every grid becomes one column, with a top border between articles |
+| Mobile margins | 24 px minimum |
+
+Do not use the Foundation Grid for the Gazette. Use scoped CSS Grid for marketing; Foundation may remain loaded during migration.
+
+## Required content order
+
+1. Brand header
+2. “Les nouvelles du local” masthead
+3. Three-article row
+4. Sarah → Martin handover feature in three columns
+5. MJ9 equipment sheet: illustration across two columns, details in one column
+6. Three closing articles
+7. Three-column pricing article
+8. Gazette footer
+9. Email sign-in popup, rendered above the page when activated
+
+## Header
+
+Left: Scoutinv wordmark.
+
+Right:
+
+- “Connexion” link opening the popup;
+- primary “Inscrire mon groupe” CTA.
+
+The header has a double rule beneath it. There are no secondary marketing links: the page is an editorial document, not a conventional site navigation bar.
+
+## Masthead
+
+Reference content:
+
+```text
+LA GAZETTE DU MATÉRIEL · ÉDITION DES RESPONSABLES
+Les nouvelles du local
+Un journal pour ce qui part à l’aventure et revient raconter son histoire.
+```
+
+The eyebrow uses small, tracked DM Mono. The title is centred, very large, and set in Newsreader. A rule closes the masthead.
+
+## First row: three articles
+
+Build a `0.8fr 1.4fr 0.8fr` grid.
+
+### Left column — Maintenance
+
+```text
+ENTRETIEN
+Le poêle D81 part en réparation.
+Une fuite a été signalée au retour. Son numéro de série permet de le mettre de côté sans confondre les autres poêles du groupe.
+```
+
+### Centre column — Lead story
+
+```text
+À LA UNE
+Votre matériel part à l’aventure. Gardez une trace de son retour.
+Scoutinv réunit les sorties, les retours, les observations et les réparations. L’information reste avec le groupe, et avec chaque exemplaire de matériel.
+```
+
+This column contains the “Inscrire mon groupe” and “Connexion” CTAs.
+
+### Right column — Next outing
+
+```text
+PROCHAINE SORTIE
+Le poste prépare son week-end.
+Trois tentes et le matériel cuisine sont confirmés. La hache N8C reste à localiser avant le départ.
+```
+
+## Handover feature
+
+Title: “Sarah passe le matériel à Martin.”
+
+Keep three value columns:
+
+| Eyebrow | Heading | Point made |
+| --- | --- | --- |
+| AVANT | Sarah n’a pas à tout raconter de mémoire. | Locations, states, and recent outings are already recorded. |
+| PENDANT | Martin apprend avec de vrais repères. | MJ9, N8C, and D81 are serial numbers for specific items. |
+| APRÈS | La prochaine relève aura elle aussi un point de départ. | Outings and repairs enrich the group’s memory. |
+
+This feature must demonstrate volunteer continuity; do not rewrite it as a productivity promise.
+
+## MJ9 equipment sheet
+
+Build a `2fr 1fr` grid: an editorial illustration of the tent on the left and a dark sheet on the right.
+
+The sheet contains:
+
+```text
+FICHE MATÉRIEL
+Tente prospecteur MJ9
+
+DERNIÈRE SORTIE
+Camp de printemps · unité des Éclaireurs
+
+SIGNALÉ PAR L’UNITÉ
+Problème avec la porte de la tente
+
+PROCHAINE ÉTAPE
+Vérifier si une réparation est nécessaire
+```
+
+The illustration may be CSS, an original photo, or generated artwork, but it must centre the object and its serial number. Do not use a generic camping stock photo.
+
+## Closing articles
+
+Use a three-column grid, with a distinct background for each article: light surface, sage, then ink.
+
+| Eyebrow | Message |
+| --- | --- |
+| NOTE DE LA RÉDACTION | What Scoutinv retains for the group: useful small facts, without adding a new chore. |
+| LE SAVIEZ-VOUS ? | A serial number tells one item’s story and prevents identical objects from being confused. |
+| POUR VOTRE GROUPE | Create the journal of your equipment, with an “Inscrire mon groupe” CTA. |
+
+## Pricing article
+
+Add one final article with a shared heading, followed by a three-column grid. Reference content:
+
+| Column | Content |
+| --- | --- |
+| Hosted version | `20 USD / 20 CAD / 20 EUR` **per year**. Scoutinv is hosted and maintained for the group. |
+| Self-hosted | No licence fee; the group manages its own hosting and environment. |
+| Open source | Scoutinv is GPLv2 software. The code can be studied, changed, and shared under that licence. Link: `https://github.com/francois/scoutinv`. |
+
+The GitHub link must include the GitHub logo, an explicit “View the source code on GitHub” label, and accessible text or name. The logo must not be the only link affordance.
+
+Do not build a complex pricing page or invent plan tiers. The yearly price communicates simplicity and affordability for volunteer groups.
+
+## Email-link sign-in
+
+### Demonstration state
+
+The intended demonstration state displays:
+
+```text
+CONNEXION
+Un lien, et c’est parti.
+francois@teksol.info
+Envoyer
+LIEN ENVOYÉ
+Un courriel de connexion vient d’être envoyé à francois@teksol.info.
+```
+
+This documents the intended success state. In production, the popup must be closed initially and show confirmation only after a successful server response.
+
+### Production behaviour
+
+- The “Connexion” button opens a modal dialog.
+- The form sends the address to the real existing session endpoint; do not simulate sending in JavaScript.
+- After success, show confirmation in an `aria-live="polite"` region.
+- On error, retain the entered address, show the error next to the field, and keep the dialog open.
+- Trap focus in the dialog; close with Escape and the close button; restore focus to the trigger.
+- The dimmed backdrop is visual only; it must not leave the underlying page keyboard-accessible.
+
+## Registration
+
+The “Inscrire mon groupe” CTA must lead to the real registration form, ideally in a final section or dedicated flow. Reuse the logic from `_registration_form.html.erb`; do not create a second implementation of the same fields or submit data to `#`.
+
+## Accessibility and quality
+
+- One `<h1>` only: “Les nouvelles du local”.
+- Preserve a meaningful heading hierarchy within articles.
+- Serial numbers must never be communicated by colour or typography alone.
+- Every button and link has an explicit accessible name.
+- Images have useful `alt` text; decorative illustrations are marked decorative.
+- Test contrast, visible focus, and rendering without web fonts.
+- Do not display the demonstration popup by default in production.
+
+## Acceptance checklist
+
+- Desktop: first row, handover, closing, and pricing all render in three columns; the MJ9 sheet renders 2/1.
+- Mobile: every column becomes vertical with no overlap or truncated text.
+- “Inscrire mon groupe” leads to the real registration flow.
+- “Connexion” opens the form, accepts an email address, and confirms the real send.
+- The price is yearly, never monthly.
+- The GPLv2 link leads to the GitHub repository with both a GitHub logo and label.
+- French and English content are localized; no marketing strings are hard-coded.


### PR DESCRIPTION
Adds self-contained English brand identity and marketing implementation guides. Documents visual tokens, typography, accessibility, landing structure, email-link sign-in, and pricing/open-source messaging. No application behavior changes.