### PR TITLE
Add development email sign-in

### DIFF
--- a/app/controllers/dev/auth_controller.rb
+++ b/app/controllers/dev/auth_controller.rb
@@ -1,0 +1,11 @@
+class Dev::AuthController < ApplicationController
+  skip_before_action :authenticate_member!
+
+  def show
+    reset_session
+    member = Member.find_by!(email: params[:email])
+    sign_in_member!(member)
+
+    redirect_to root_path, notice: t(".authenticated_as", email: member.email)
+  end
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -73,6 +73,9 @@ en:
     perishable: Perishable
     tent: Tent
     tools: Tools
+  dev:
+    auth:
+      authenticated_as: "Authenticated as %{email}"
   footer:
     logout: Logout
   groups:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -76,6 +76,9 @@ fr:
     perishable: Périssable
     tent: Tente
     tools: Outils
+  dev:
+    auth:
+      authenticated_as: "Authentifié en tant que %{email}"
   footer:
     logout: Fermer la session
   groups:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,10 @@
 Rails.application.routes.draw do
   root to: "home#show"
 
+  if Rails.env.development?
+    get "dev/auth", to: "dev/auth#show"
+  end
+
   resources :sessions, only: %i[ index new create show destroy ]
 
   resources :events do

--- a/test/controllers/dev/auth_controller_test.rb
+++ b/test/controllers/dev/auth_controller_test.rb
@@ -1,0 +1,49 @@
+require "test_helper"
+
+class Dev::AuthControllerTest < ActionDispatch::IntegrationTest
+  include LoginTestHelper
+
+  test "signs in the member from the email address" do
+    with_dev_auth_route do
+      get "/dev/auth", params: { email: members(:baloo_10eme).email }, headers: english_headers
+
+      assert_redirected_to root_path
+      assert_equal "Authenticated as #{members(:baloo_10eme).email}", flash[:notice]
+
+      assert_equal members(:baloo_10eme), controller.send(:current_member)
+    end
+  end
+
+  test "replaces the signed-in member" do
+    login_as(members(:baloo_10eme))
+
+    with_dev_auth_route do
+      get "/dev/auth", params: { email: members(:baloo_41eme).email }, headers: english_headers
+
+      assert_equal members(:baloo_41eme), controller.send(:current_member)
+    end
+  end
+
+  test "does not add the route outside development" do
+    assert_not Rails.application.routes.routes.any? { |route| route.path.spec.to_s.include?("dev/auth") }
+  end
+
+  private
+
+  def with_dev_auth_route(&)
+    with_routing do |routes|
+      routes.draw do
+        root to: "home#show"
+        get "dev/auth", to: "dev/auth#show"
+      end
+
+      yield
+    end
+  end
+
+  def english_headers
+    {
+      "Accept-Language" => "en-US,en;q=0.9",
+    }
+  end
+end


### PR DESCRIPTION
Adds a development-only endpoint for signing in by member email. The endpoint replaces the active session, redirects home, and shows a localized status message. Tests cover sign-in, session replacement, and route availability.